### PR TITLE
CMake: Use PCRE2 system library when available

### DIFF
--- a/build/cmake/lib/regex.cmake
+++ b/build/cmake/lib/regex.cmake
@@ -7,8 +7,9 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-if(wxUSE_REGEX)
-    set(wxUSE_REGEX builtin)
+if(wxUSE_REGEX STREQUAL "builtin")
+    # TODO: implement building PCRE2 via its CMake file, using
+    # add_subdirectory or ExternalProject_Add
     wx_add_builtin_library(wxregex
         3rdparty/pcre/src/pcre2_auto_possess.c
         3rdparty/pcre/src/pcre2_compile.c
@@ -42,4 +43,8 @@ if(wxUSE_REGEX)
     set(REGEX_INCLUDE_DIRS ${wxSOURCE_DIR}/3rdparty/pcre/src/wx)
     target_compile_definitions(wxregex PRIVATE __WX__ HAVE_CONFIG_H)
     target_include_directories(wxregex PRIVATE ${wxSETUP_HEADER_PATH} ${wxSOURCE_DIR}/include ${REGEX_INCLUDE_DIRS})
+elseif(wxUSE_REGEX)
+    find_package(PCRE2 REQUIRED)
+    set(REGEX_LIBRARIES ${PCRE2_LIBRARIES})
+    set(REGEX_INCLUDE_DIRS ${PCRE2_INCLUDE_DIRS})
 endif()

--- a/build/cmake/modules/FindPCRE2.cmake
+++ b/build/cmake/modules/FindPCRE2.cmake
@@ -1,0 +1,43 @@
+# Find the PCRE2 headers and libraries.
+#
+#  Optionally define the following variables:
+#     PCRE2_CODE_UNIT_WIDTH - code unit width: 8 (default), 16 or 32 bit.
+#
+#  This module defines the following variables:
+#     PCRE2_FOUND        - true if PCRE2 is found.
+#     PCRE2_INCLUDE_DIRS - list of PCRE2 include directories.
+#     PCRE2_LIBRARIES    - list of PCRE2 libraries.
+
+if(NOT PCRE2_CODE_UNIT_WIDTH)
+    set(PCRE2_CODE_UNIT_WIDTH 8)
+endif()
+
+if(NOT PCRE2_CODE_UNIT_WIDTH EQUAL PCRE2_CODE_UNIT_WIDTH_USED)
+    unset(PCRE2_CODE_UNIT_WIDTH_USED CACHE)
+    unset(PCRE2_FOUND CACHE)
+    unset(PCRE2_INCLUDE_DIRS CACHE)
+    unset(PCRE2_LIBRARIES CACHE)
+endif()
+
+set(PCRE2_CODE_UNIT_WIDTH_USED "${PCRE2_CODE_UNIT_WIDTH}" CACHE INTERNAL "")
+
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH})
+
+find_path(PCRE2_INCLUDE_DIRS
+    NAMES pcre2.h
+    HINTS ${PC_PCRE2_INCLUDEDIR}
+          ${PC_PCRE2_INCLUDE_DIRS}
+)
+
+find_library(PCRE2_LIBRARIES
+    NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH}
+    HINTS ${PC_PCRE2_LIBDIR}
+          ${PC_PCRE2_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE2 REQUIRED_VARS PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS VERSION_VAR PC_PCRE2_VERSION)
+
+mark_as_advanced(PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS)

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -96,8 +96,19 @@ wx_option(wxUSE_REPRODUCIBLE_BUILD "enable reproducable build" OFF)
 # ---------------------------------------------------------------------------
 # external libraries
 # ---------------------------------------------------------------------------
+set(PCRE2_CODE_UNIT_WIDTH 8)
+if(wxUSE_UNICODE AND (NOT DEFINED wxUSE_UNICODE_UTF8 OR NOT wxUSE_UNICODE_UTF8))
+    # This is also checked in setup.cmake, but setup.cmake will run after options.cmake.
+    include(CheckTypeSize)
+    check_type_size(wchar_t SIZEOF_WCHAR_T)
+    if(HAVE_SIZEOF_WCHAR_T AND SIZEOF_WCHAR_T EQUAL 2)
+        set(PCRE2_CODE_UNIT_WIDTH 16)
+    elseif(HAVE_SIZEOF_WCHAR_T AND SIZEOF_WCHAR_T EQUAL 4)
+        set(PCRE2_CODE_UNIT_WIDTH 32)
+    endif()
+endif()
 
-wx_add_thirdparty_library(wxUSE_REGEX REGEX "enable support for wxRegEx class" DEFAULT builtin)
+wx_add_thirdparty_library(wxUSE_REGEX PCRE2 "enable support for wxRegEx class")
 wx_add_thirdparty_library(wxUSE_ZLIB ZLIB "use zlib for LZW compression" DEFAULT_APPLE sys)
 wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing" DEFAULT_APPLE sys)
 wx_add_thirdparty_library(wxUSE_LIBJPEG JPEG "use libjpeg (JPEG file format)")


### PR DESCRIPTION
Similar to other system libraries, use the builtin version on Windows and macOS
and try to find the system library on Unix.

Find the correct PCRE2 library based on the code point width that will be used.